### PR TITLE
Use fork of Puma that raises the URI limit. This fixes #4.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem 'sinatra-initializers'
 gem 'activesupport', require: false
 gem 'rack-standards'
 gem 'rack-contrib'
-gem 'puma'
+# Using fork of Puma with a raised URI length limit. Puma's limit is 2048 chars. This forks limit is 10240.
+gem 'puma', github: 'producthunt/puma'
 gem 'erubis'
 gem 'i18n'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,12 @@ GIT
       sinatra (~> 1.4.0)
       tilt (~> 1.3)
 
+GIT
+  remote: git://github.com/producthunt/puma.git
+  revision: 9ad1b20dee95e93ff33924a8255042247ad29d14
+  specs:
+    puma (2.15.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,7 +58,6 @@ GEM
     pry-byebug (1.3.2)
       byebug (~> 2.7)
       pry (~> 0.9.12)
-    puma (2.15.3)
     rack (1.6.4)
     rack-contrib (1.4.0)
       git-version-bump (~> 0.15)
@@ -120,7 +125,7 @@ DEPENDENCIES
   json
   pry
   pry-byebug
-  puma
+  puma!
   rack-contrib
   rack-standards
   rack-test


### PR DESCRIPTION
There is no limit for URI's. Only old versions of IE cannot handle long URI's. For our usecase, limit is not a concern (URL's are used internally & then uploaded to Twitter/Facebook/Etc).