### PR TITLE
Generate sip_poll image template

### DIFF
--- a/app/css/sip_poll.css
+++ b/app/css/sip_poll.css
@@ -1,0 +1,72 @@
+html, body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  font-size: 18px;
+  font-weight: 300;
+  height: 300px;
+  width: 560px;
+}
+
+.container {
+  background-size: cover;
+  padding: 0 20%;
+}
+
+.poll { 
+  display: flex;
+  align-self: center;
+  flex-direction: column;
+}
+
+.poll--poll-question {
+  color: white;
+  font-family: Georgia, serif;
+  font-weight: 600;
+  padding-bottom: 20px;
+}
+
+.poll--content {
+  padding: 0 10px;
+}
+
+.poll--content--poll-option {
+  border: 1px solid rgba(221,221,221,0.2);
+  border-radius: 40px;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 20px;
+  padding: 20px;
+  position: relative;
+}
+
+.poll--content--poll-option--percentage-container {
+  background: rgba(221,221,221,0.5);
+  border-radius: 40px;
+  height: 93%;
+  width: 95%;
+  left: 1%;
+  position: absolute;
+  top: 5%;
+  z-index: -1;
+}
+
+.voted {
+  background: #ddd !important;
+}
+
+.votedText {
+  color: #4A90E2;
+}
+
+.grey { 
+  color: rgba(221,221,221,0.5);
+}
+
+.offWhite {
+  color: #DDDDDD;
+}
+
+.poll--content--poll-option--text { z-index: 2; }
+
+.poll--content--poll-option--percentage {
+  float: right;
+}

--- a/app/image_templates/sip_poll.rb
+++ b/app/image_templates/sip_poll.rb
@@ -1,0 +1,19 @@
+module ImageTemplates
+  class SipPoll < Base
+    def allowed_options
+      %w(poll_question poll_options thumbnail_uuid)
+    end
+
+    def erb_template
+      'app/views/sip_poll.erb'
+    end
+
+    def css_stylesheet
+      'app/css/sip_poll.css'
+    end
+
+    def image_width
+      450
+    end
+  end
+end

--- a/app/views/sip_poll.erb
+++ b/app/views/sip_poll.erb
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body
+    style="background: url('http://ph-files.imgix.net/<%= options[:thumbnail_uuid] %>?auto=format&balph=60&blend=000000&blur=20&bm=normal&fit=crop&h=1280&w=720');">
+    <div class="container">
+      <div class="poll">
+        <h2 class="poll--poll-question">
+          <%= options[:poll_question] %>
+        </h2>
+        <div class="poll--content">
+          <% options[:poll_options].each do |poll_option| %>
+            <div class="poll--content--poll-option">
+              <div class="poll--content--poll-option--text">
+                <span class="poll--content--poll-option--option <%= poll_option['voted'] ? 'votedText' : 'grey' %>">
+                  <%= poll_option["option"] %>
+                </span>
+                <span class="poll--content--poll-option--percentage <%= poll_option['voted'] ? 'offWhite' : 'grey' %>">
+                  <%= poll_option["percentage"] %>%
+                </span>
+              </div>
+              <div 
+                class="poll--content--poll-option--percentage-container <%= poll_option['voted'] ? 'voted' : nil %>"
+                style="width: <%= poll_option["percentage"] %>%;"
+              ></div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds support for generating a sip poll image template, as seen below:

<img width="1136" alt="screen shot 2018-07-26 at 3 31 22 pm" src="https://user-images.githubusercontent.com/922353/43289439-a18b1d68-90f0-11e8-8651-e2d341f6649f.png">
