### PR TITLE
Update positioning for generated Sip Poll image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'builder'
 gem 'json'
 gem 'dotenv'
 gem 'imgkit'
-gem 'rumoji'
+gem 'rumoji', git: 'https://github.com/mwunsch/rumoji'
 gem 'gemoji'
 gem 'pry', require: false, group: :production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,12 @@ GIT
       tilt (~> 1.3)
 
 GIT
+  remote: https://github.com/mwunsch/rumoji
+  revision: ce802a9911121991a3cd68306fb926e5dd4eebaf
+  specs:
+    rumoji (0.5.0)
+
+GIT
   remote: https://github.com/producthunt/puma
   revision: 9ad1b20dee95e93ff33924a8255042247ad29d14
   specs:
@@ -86,7 +92,6 @@ GEM
       ruby-progressbar (~> 1.7)
       tins (<= 1.6.0)
     ruby-progressbar (1.9.0)
-    rumoji (0.5.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -128,7 +133,7 @@ DEPENDENCIES
   rb-readline
   rspec
   rubocop (~> 0.35.0)
-  rumoji
+  rumoji!
   simplecov
   sinatra
   sinatra-contrib!

--- a/app/css/sip_poll.css
+++ b/app/css/sip_poll.css
@@ -1,7 +1,7 @@
 html, body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   font-size: 18px;
-  font-weight: 300;
+  font-weight: 400;
   height: 300px;
   width: 560px;
 }
@@ -9,9 +9,10 @@ html, body {
 .container {
   background-size: cover;
   padding: 0 20%;
+  padding-bottom: 10px;
 }
 
-.poll { 
+.poll {
   display: flex;
   align-self: center;
   flex-direction: column;
@@ -19,8 +20,7 @@ html, body {
 
 .poll--poll-question {
   color: white;
-  font-family: Georgia, serif;
-  font-weight: 600;
+  font-weight: 400;
   padding-bottom: 20px;
 }
 
@@ -38,35 +38,45 @@ html, body {
   position: relative;
 }
 
-.poll--content--poll-option--percentage-container {
-  background: rgba(221,221,221,0.5);
-  border-radius: 40px;
-  height: 93%;
-  width: 95%;
-  left: 1%;
-  position: absolute;
-  top: 5%;
-  z-index: -1;
+.poll--content--poll-option--text {
+  width: 100%;
+  z-index: 2;
 }
-
-.voted {
-  background: #ddd !important;
-}
-
-.votedText {
-  color: #4A90E2;
-}
-
-.grey { 
-  color: rgba(221,221,221,0.5);
-}
-
-.offWhite {
-  color: #DDDDDD;
-}
-
-.poll--content--poll-option--text { z-index: 2; }
 
 .poll--content--poll-option--percentage {
   float: right;
+}
+
+.poll--content--poll-option--percentage-container {
+  background: #ddd;
+  border-radius: 40px;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: -1;
+}
+
+.poll--content--poll-option--percentage-container-fill {
+  background: #bcbcbc;
+  border-radius: 40px;
+  box-sizing: border-box;
+  height: 100%;
+  left: 0;
+  min-width: 80px;
+  position: absolute;
+  top: 0;
+  z-index: -1;
+}
+
+.bold { font-weight: bold; }
+
+.voted {
+  background: #4A90E2;
+}
+
+.poll-icon {
+  margin-right: 6px;
+  vertical-align: -3px;
 }

--- a/app/emoji_helper.rb
+++ b/app/emoji_helper.rb
@@ -1,7 +1,7 @@
 module EmojiHelper
   IMAGE_PARAMS = %(style="vertical-align:middle" width="20" height="20")
 
-  def self.emojify(content)
+  def self.emojify(content, strip: false)
     content = Rumoji.encode(content)
 
     content.to_str.gsub(/:([\w+-]+):/) do |match|
@@ -10,7 +10,7 @@ module EmojiHelper
       if emoji
         %(<img alt="#{Regexp.last_match(1)}" src="#{ShareMeow::App.base_url}/images/emoji/#{emoji.image_filename}" #{IMAGE_PARAMS} />)
       else
-        match
+        strip ? nil : match
       end
     end
   end

--- a/app/image_templates/sip_poll.rb
+++ b/app/image_templates/sip_poll.rb
@@ -1,7 +1,10 @@
 module ImageTemplates
   class SipPoll < Base
     def render_options
-      @options[:poll_options] = percentage_for_css(@options[:poll_options])
+      @options[:poll_question] = EmojiHelper.emojify(@options[:poll_question])
+      @options[:poll_options] = @options[:poll_options].map do |option|
+        option.merge({ 'option': EmojiHelper.emojify(option['option'], strip: true) })
+      end
       super
     end
 
@@ -20,25 +23,5 @@ module ImageTemplates
     def image_width
       450
     end
-
-    private
-
-    def percentage_for_css(poll_options)
-      poll_options.map do |poll_option|
-        # NOTE (kristian): Kinda hacky approach to some wkhtmltoimage limitations by
-        # manually defining an offset percentage for this container
-        percentage = if poll_option['percentage'] > 1
-          poll_option['percentage'] - 1
-        else
-          0
-        end
-
-        {
-          option: poll_option['option'],
-          percentage: poll_option['percentage'],
-          css_percentage: "#{percentage}%"
-        }
-      end
-    end
-  end
+9 end
 end

--- a/app/views/sip_poll.erb
+++ b/app/views/sip_poll.erb
@@ -14,17 +14,19 @@
           <% options[:poll_options].each do |poll_option| %>
             <div class="poll--content--poll-option">
               <div class="poll--content--poll-option--text">
-                <span class="poll--content--poll-option--option <%= poll_option['voted'] ? 'votedText' : 'grey' %>">
+                <span class="poll--content--poll-option--option <%= poll_option['voted'] ? 'bold' : nil %>">
+                  <img class='poll-icon'  src="https://s3.amazonaws.com/producthunt/static/sip/sip-poll-<%= poll_option['voted'] ? 'check' : 'empty' %>.svg" />
                   <%= poll_option[:option] %>
-                </span>
-                <span class="poll--content--poll-option--percentage <%= poll_option['voted'] ? 'offWhite' : 'grey' %>">
-                  <%= poll_option[:percentage] %>%
                 </span>
               </div>
               <div
-                class="poll--content--poll-option--percentage-container <%= poll_option['voted'] ? 'voted' : nil %>"
-                style="width: <%= poll_option[:css_percentage] %>;"
+                class="poll--content--poll-option--percentage-container"
               ></div>
+                <div
+                  class="poll--content--poll-option--percentage-container-fill <%= poll_option['voted'] ? 'voted' : nil %>"
+                  style="width: <%= poll_option['percentage'] %>%;"
+                >
+                </div>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
- Pass `strip` option to EmojiHelper: if `true`, remove any emoji text (i.e. `:dog:`) that isn't matched by a real emoji
- Update the generated image for Sip Poll sharing

e.g.

<img width="568" alt="screen shot 2018-08-16 at 2 25 32 pm" src="https://user-images.githubusercontent.com/922353/44230250-41f04d80-a160-11e8-8ba8-de41553fda58.png">
